### PR TITLE
Set default shell to bash for created users

### DIFF
--- a/hadoop/user_macro.sls
+++ b/hadoop/user_macro.sls
@@ -7,6 +7,7 @@
     - uid: {{ uid }}
     - gid: {{ uid }}
     - home: {{ userhome }}
+    - shell: /bin/bash
     - groups: ['hadoop']
     - require:
       - group: {{ username }}


### PR DESCRIPTION
Previously the default shell was not set
so it was /bin/sh in my case on ubuntu 14.04
