### PR TITLE
Add HADOOP_HOME env var and adds hadoop/bin to defalt path

### DIFF
--- a/hadoop/files/hadoop.sh.jinja
+++ b/hadoop/files/hadoop.sh.jinja
@@ -1,2 +1,4 @@
-export HADOOP_PREFIX=/usr/lib/hadoop
+export HADOOP_PREFIX={{ alt_home }}
 export HADOOP_CONF_DIR={{ hadoop_config }}
+export HADOOP_HOME={{ alt_home }}
+export PATH={{ alt_home }}/bin:$PATH

--- a/hadoop/init.sls
+++ b/hadoop/init.sls
@@ -90,6 +90,7 @@ rename-config:
     - group: root
     - context:
       hadoop_config: {{ hadoop['alt_config'] }}
+      alt_home: {{ hadoop.get('alt_home', '/usr/lib/hadoop') }}
 
 {% if (hadoop['major_version'] == '1') and not hadoop.cdhmr1 %}
 {% set real_config_src = hadoop['real_home'] + '/conf' %}


### PR DESCRIPTION
This patch adds missing HADOOP_HOME variable which
is used by other software such as Apache mesos.
And adds the hadoop bin folder to the default path
of all users. This way every user in the
system is able to execute hadoop commands.

This patch also fixes a bug where the HADOOP_PREFIX
variable was hard coded where it should have been using
the settings of the user / default defined in
hadoop/settings.sls
