### PR TITLE
Don't force specific usage of role upon user #10

### DIFF
--- a/hadoop/hdfs/load.sls
+++ b/hadoop/hdfs/load.sls
@@ -1,8 +1,7 @@
 {%- from 'hadoop/settings.sls' import hadoop with context %}
 {%- from 'hadoop/hdfs/settings.sls' import hdfs with context %}
 
-{%- set all_roles    = salt['grains.get']('roles', []) %}
-{%- if 'hadoop_master' in all_roles %}
+{% if salt['match.' ~ hadoop.targeting_method](hdfs.namenode_target) %}
 
 {%- for filename in hdfs.load.keys() %}
 {%- set url = hdfs.load.get(filename, '') %}

--- a/hadoop/mapred/init.sls
+++ b/hadoop/mapred/init.sls
@@ -34,7 +34,7 @@
 
 # create the /tmp directory
 
-{%- if 'hadoop_master' in salt['grains.get']('roles', []) %}
+{% if mapred.is_jobtracker %}
 # hadoop 1 apparently cannot set the sticky bit
 {%- if hadoop.major_version == '2' %}
 {{ hdfs_mkdir('/tmp', 'hdfs', None, 1777, hadoop.dfs_cmd) }}
@@ -47,7 +47,7 @@
 
 {%- if hadoop['major_version'] == '1' %}
 
-{%- if 'hadoop_master' in salt['grains.get']('roles', []) %}
+{% if mapred.is_jobtracker %}
 /etc/init.d/hadoop-jobtracker:
   file.managed:
     - source: salt://hadoop/files/{{ hadoop.initscript }}
@@ -66,8 +66,7 @@ hadoop-jobtracker:
     - enable: True
 {%- endif %}
 
-{%- if 'hadoop_slave' in salt['grains.get']('roles', []) %}
-
+{% if mapred.is_datatracker %}
 /etc/init.d/hadoop-tasktracker:
   file.managed:
     - source: salt://hadoop/files/{{ hadoop.initscript }}
@@ -86,4 +85,5 @@ hadoop-tasktracker:
     - enable: True
 
 {%- endif %}
+
 {%- endif %}

--- a/hadoop/mapred/settings.sls
+++ b/hadoop/mapred/settings.sls
@@ -1,3 +1,5 @@
+{%- from "hadoop/settings.sls" import hadoop with context %}
+
 {% set p  = salt['pillar.get']('mapred', {}) %}
 {% set pc = p.get('config', {}) %}
 {% set g  = salt['grains.get']('mapred', {}) %}
@@ -10,10 +12,16 @@
 {%- set history_dir      = gc.get('history_dir', pc.get('history_dir', '/mr-history')) %}
 {%- set history_intermediate_done_dir = history_dir + '/tmp' %}
 {%- set history_done_dir = history_dir + '/done' %}
+{%- set jobtracker_target = gc.get('jobtracker_target', pc.get('jobtracker_target', 'roles:hadoop_master')) %}
+{%- set datatracker_target = gc.get('datatracker_target', pc.get('datatracker_target', 'roles:hadoop_slave')) %}
 
-{%- set jobtracker_host = salt['mine.get']('roles:hadoop_master', 'network.interfaces', 'grain').keys()|first() -%}
+{%- set jobtracker_host  = salt['mine.get'](jobtracker_target, 'network.interfaces', expr_form=hadoop.targeting_method)|first %}
 {%- set local_disks     = salt['grains.get']('mapred_data_disks', ['/data']) %}
 {%- set config_mapred_site = gc.get('mapred-site', pc.get('mapred-site', {})) %}
+
+
+{% set is_jobtracker = salt['match.' ~ hadoop.targeting_method](jobtracker_target) %}
+{% set is_datatracker = salt['match.' ~ hadoop.targeting_method](datatracker_target) %}
 
 {%- set mapred = {} %}
 {%- do mapred.update({ 'jobtracker_port'               : jobtracker_port|string(),
@@ -21,6 +29,10 @@
                        'jobhistory_port'               : jobhistory_port|string(),
                        'jobhistory_webapp_port'        : jobhistory_webapp_port|string(),
                        'jobtracker_host'               : jobtracker_host,
+                       'jobtracker_target'             : jobtracker_target,
+                       'datatracker_target'            : datatracker_target,
+                       'is_jobtracker'                 : is_jobtracker,
+                       'is_datatracker'                : is_datatracker,
                        'history_dir'                   : history_dir,
                        'history_intermediate_done_dir' : history_intermediate_done_dir,
                        'history_done_dir'              : history_done_dir,

--- a/hadoop/settings.sls
+++ b/hadoop/settings.sls
@@ -91,6 +91,7 @@
 {%- set default_log_root = '/var/log/hadoop' %}
 {%- set log_root         = gc.get('log_root', pc.get('log_root', default_log_root)) %}
 {%- set initscript       = 'hadoop.init' %}
+{%- set targeting_method = g.get('targeting_method', p.get('targeting_method', 'grain')) %}
 
 {%- if version_info['major_version'] == '1' %}
 {%- set dfs_cmd = alt_home + '/bin/hadoop dfs' %}
@@ -122,4 +123,5 @@
                           'log_root'         : log_root,
                           'default_log_root' : default_log_root,
                           'config_core_site' : config_core_site,
+                          'targeting_method': targeting_method,
                       }) %}

--- a/hadoop/yarn/init.sls
+++ b/hadoop/yarn/init.sls
@@ -3,7 +3,6 @@
 {%- from "hadoop/mapred/settings.sls" import mapred with context %}
 {%- from "hadoop/user_macro.sls" import hadoop_user with context %}
 {%- from 'hadoop/hdfs_mkdir_macro.sls' import hdfs_mkdir with context %}
-{%- set all_roles    = salt['grains.get']('roles', []) %}
 
 # TODO: no users implemented in settings yet
 {%- set hadoop_users = hadoop.get('users', {}) %}
@@ -79,7 +78,7 @@ fix-executor-permissions:
     - user: root
     - template: jinja
 
-{%- if 'hadoop_master' in salt['grains.get']('roles', []) %}
+{% if hdfs.is_namenode %}
 
 # add mr-history directories for Hadoop 2
 {%- set yarn_site = yarn.config_yarn_site %}
@@ -102,7 +101,6 @@ fix-executor-permissions:
       hadoop_user: hdfs
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
-      node_roles: {{ all_roles }}
 
 hadoop-historyserver:
   service.running:
@@ -126,7 +124,7 @@ hadoop-resourcemanager:
     - enable: True
 {% endif %}
 
-{%- if 'hadoop_slave' in salt['grains.get']('roles', []) %}
+{% if hdfs.is_datanode %}
 
 /etc/init.d/hadoop-nodemanager:
   file.managed:

--- a/hadoop/yarn/settings.sls
+++ b/hadoop/yarn/settings.sls
@@ -11,8 +11,9 @@
 {%- set nodemanager_port            = gc.get('nodemanager_port', pc.get('nodemanager_port', '50024')) %}
 {%- set nodemanager_webapp_port     = gc.get('nodemanager_webapp_port', pc.get('nodemanager_webapp_port', '50025')) %}
 {%- set nodemanager_localizer_port  = gc.get('nodemanager_localizer_port', pc.get('nodemanager_localizer_port', '50026')) %}
+{%- set resourcemanager_target      = gc.get('resourcemanager_target', pc.get('resourcemanager_target', 'roles:hadoop_master'))
+{%- set resourcemanager_host        = salt['mine.get'](resourcemanager_target, 'network.interfaces', expr_form=hadoop.targeting_method).keys()|first() %}
 
-{%- set resourcemanager_host        = salt['mine.get']('roles:hadoop_master', 'network.interfaces', 'grain').keys()|first() -%}
 {%- set local_disks                 = salt['grains.get']('yarn_data_disks', ['/yarn_data']) %}
 {%- set config_yarn_site            = gc.get('yarn-site', pc.get('yarn-site', {})) %}
 {%- set config_capacity_scheduler   = gc.get('capacity-scheduler', pc.get('capacity-scheduler', {})) %}

--- a/pillar.example
+++ b/pillar.example
@@ -2,6 +2,7 @@
 
 hadoop:
   version: apache-1.2.1 # ['apache-1.2.1', 'apache-2.2.0', 'hdp-1.3.0', 'hdp-2.2.0', 'cdh-4.5.0', 'cdh-4.5.0-mr1']
+  targeting_method: grain # [compound, glob] also supported
   users:
     hadoop: 6000
     hdfs: 6001
@@ -19,6 +20,8 @@ hadoop:
 
 hdfs:
   config:
+    namenode_target: "roles:hadoop_master" # Specify compound matching string to match all your namenodes
+    datanode_target: "roles:hadoop_slave" # Specify compound matching string to match all your datanodes e.g. if you were to use pillar I@datanode:true
     namenode_port: 8020
     namenode_http_port: 50070
     secondarynamenode_http_port: 50090
@@ -35,6 +38,8 @@ hdfs:
 
 mapred:
   config:
+    jobtracker_target: "roles:hadoop_master"
+    datatracker_target: "roles:hadoop_slave"
     jobtracker_port: 9001
     jobtracker_http_port: 50030
     jobhistory_port: 10020


### PR DESCRIPTION
Make the targeting of the namenode, datanode, jobtracker
and any indepdent targetable by using pillar, nodegroups,
grain roles. User can now specify in pillar how
the namenode, datanode should be targeted.

Uses compound matching where the user can
change the matching string to his own liking in pillar
Inside the sls files to know whether the namenode
or datanode package / service should be used we use
salt match.{compound|glob} directly.

Patch is only tested with HDFS and mapred. Other
components may got broken.

This patch _should_ be backwards compatible as
previous role based usage is current default
for for all configurable strings

Closes: https://github.com/saltstack-formulas/hadoop-formula/issues/10
