### PR TITLE
Strip unicode chars from example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -75,26 +75,26 @@ yarn:
       yarn.resourcemanager.scheduler.class:
         value: org.apache.hadoop.yarn.server.resourcemanager.scheduler.capacity.CapacityScheduler
     capacity-scheduler:
-      yarn.scheduler.capacity.maximum-applications:
-        value: 10000
-      yarn.scheduler.capacity.resource-calculator:
-        value: org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator
-      yarn.scheduler.capacity.root.queues:
-        value: default,customqueue
-      yarn.scheduler.capacity.root.capacity:
-        value: 100
-      yarn.scheduler.capacity.root.default.capacity:
-        value: 70
-      yarn.scheduler.capacity.root.default.user-limit-factor:
-        value: 1
-      yarn.scheduler.capacity.root.default.maximum-capacity:
-        value: 100
-      yarn.scheduler.capacity.root.default.state:
-        value: RUNNING
-      yarn.scheduler.capacity.root.default.acl_submit_applications:
-        value: '*'
-      yarn.scheduler.capacity.root.default.acl_administer_queue:
-        value: '*'
+      yarn.scheduler.capacity.maximum-applications:
+        value: 10000
+      yarn.scheduler.capacity.resource-calculator:
+        value: org.apache.hadoop.yarn.util.resource.DefaultResourceCalculator
+      yarn.scheduler.capacity.root.queues:
+        value: default,customqueue
+      yarn.scheduler.capacity.root.capacity:
+        value: 100
+      yarn.scheduler.capacity.root.default.capacity:
+        value: 70
+      yarn.scheduler.capacity.root.default.user-limit-factor:
+        value: 1
+      yarn.scheduler.capacity.root.default.maximum-capacity:
+        value: 100
+      yarn.scheduler.capacity.root.default.state:
+        value: RUNNING
+      yarn.scheduler.capacity.root.default.acl_submit_applications:
+        value: '*'
+      yarn.scheduler.capacity.root.default.acl_administer_queue:
+        value: '*'
       yarn.scheduler.capacity.root.customqueue.capacity:
         value: 30
       yarn.scheduler.capacity.root.customqueue.maximum-am-resource-percent:


### PR DESCRIPTION
The pillar example contained non-ascii characters that
if copy/pasted into an SLS file cause strange failures