### PR TITLE
Replace global PATH change with alternatives symlinks for hadoop binaries

### DIFF
--- a/hadoop/files/hadoop.sh.jinja
+++ b/hadoop/files/hadoop.sh.jinja
@@ -1,4 +1,3 @@
 export HADOOP_PREFIX={{ alt_home }}
 export HADOOP_HOME={{ alt_home }}
 export HADOOP_CONF_DIR={{ hadoop_config }}
-export PATH={{ alt_home }}/bin:$PATH

--- a/hadoop/files/hadoop.sh.jinja
+++ b/hadoop/files/hadoop.sh.jinja
@@ -1,3 +1,4 @@
 export HADOOP_PREFIX={{ alt_home }}
+export HADOOP_HOME={{ alt_home }}
 export HADOOP_CONF_DIR={{ hadoop_config }}
 export PATH={{ alt_home }}/bin:$PATH

--- a/hadoop/init.sls
+++ b/hadoop/init.sls
@@ -57,6 +57,7 @@ unpack-hadoop-dist:
       - alternatives: hadoop-home-link
       - alternatives: hadoop-bin-link
       - alternatives: hdfs-bin-link
+      - alternatives: mapred-bin-link
       - alternatives: yarn-bin-link
 
 hadoop-home-link:
@@ -75,6 +76,12 @@ hdfs-bin-link:
   alternatives.install:
     - link: /usr/bin/hdfs
     - path: {{ hadoop['alt_home'] }}/bin/hdfs
+    - priority: 30
+
+mapred-bin-link:
+  alternatives.install:
+    - link: /usr/bin/mapred
+    - path: {{ hadoop['alt_home'] }}/bin/mapred
     - priority: 30
 
 yarn-bin-link:

--- a/hadoop/init.sls
+++ b/hadoop/init.sls
@@ -55,11 +55,32 @@ unpack-hadoop-dist:
 {%- endif %}
     - require_in:
       - alternatives: hadoop-home-link
+      - alternatives: hadoop-bin-link
+      - alternatives: hdfs-bin-link
+      - alternatives: yarn-bin-link
 
 hadoop-home-link:
   alternatives.install:
     - link: {{ hadoop['alt_home'] }}
     - path: {{ hadoop['real_home'] }}
+    - priority: 30
+
+hadoop-bin-link:
+  alternatives.install:
+    - link: /usr/bin/hadoop
+    - path: {{ hadoop['alt_home'] }}/bin/hadoop
+    - priority: 30
+
+hdfs-bin-link:
+  alternatives.install:
+    - link: /usr/bin/hdfs
+    - path: {{ hadoop['alt_home'] }}/bin/hdfs
+    - priority: 30
+
+yarn-bin-link:
+  alternatives.install:
+    - link: /usr/bin/yarn
+    - path: {{ hadoop['alt_home'] }}/bin/yarn
     - priority: 30
 
 {%- if hadoop.cdhmr1 %}


### PR DESCRIPTION
This PR removes the existing PATH modification putting /usr/lib/hadoop/bin before the system PATH from the hadoop profile in favor of explicit alternatives links (for hadoop, hdfs, yarn and mapred). It is not intended to change the perceived behavior of the installation but does make it more similar to the packages provided by Ambari and Cloudera manager.