### PR TITLE
HDFS services should restart on config changes

### DIFF
--- a/hadoop/hdfs/init.sls
+++ b/hadoop/hdfs/init.sls
@@ -64,12 +64,18 @@
     - source: salt://hadoop/conf/hdfs/core-site.xml
     - template: jinja
     - mode: 644
+    - watch_in:
+      - service: hdfs-services
+      - service: hdfs-nn-services
 
 {{ hadoop.alt_config }}/hdfs-site.xml:
   file.managed:
     - source: salt://hadoop/conf/hdfs/hdfs-site.xml
     - template: jinja
     - mode: 644
+    - watch_in:
+      - service: hdfs-services
+      - service: hdfs-nn-services
 
 {{ hadoop.alt_config }}/masters:
   file.managed:


### PR DESCRIPTION
Tested on Debian Wheezy and salt v2016.3.2.

The `watch_in` could be applied to other config files as well. If it should be, I can add them. I can't tests the others well enough to edit the behavior because I run a single machine pseudo-distributed setup.