### PR TITLE
Add support for apache 2.7.3 replacing 2.7.1

### DIFF
--- a/hadoop/settings.sls
+++ b/hadoop/settings.sls
@@ -43,9 +43,9 @@
                                         'source_hash'   : g.get('source_hash', p.get('source_hash', '')),
                                         'major_version' : '2',
                                       },
-                     'apache-2.7.1' : { 'version'       : '2.7.1',
-                                        'version_name'  : 'hadoop-2.7.1',
-                                        'source_url'    : g.get('source_url', p.get('source_url', 'http://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz')),
+                     'apache-2.7.3' : { 'version'       : '2.7.3',
+                                        'version_name'  : 'hadoop-2.7.3',
+                                        'source_url'    : g.get('source_url', p.get('source_url', 'http://archive.apache.org/dist/hadoop/core/hadoop-2.7.3/hadoop-2.7.3.tar.gz')),
                                         'source_hash'   : g.get('source_hash', p.get('source_hash', '')),
                                         'major_version' : '2',
                                       },
@@ -134,7 +134,7 @@
                    }%}
 
 {%- set versions         = p.get('versions', default_versions) %}
-{%- set version_info     = versions.get(dist_id, versions['apache-2.7.1']) %}
+{%- set version_info     = versions.get(dist_id, versions['apache-2.7.3']) %}
 {%- set alt_home         = salt['pillar.get']('hadoop:prefix', '/usr/lib/hadoop') %}
 {%- set real_home        = '/usr/lib/' + version_info['version_name'] %}
 {%- set alt_config       = gc.get('directory', pc.get('directory', '/etc/hadoop/conf')) %}


### PR DESCRIPTION
Simple change in the settings.sls file to support latest 2.7 release of hadoop