### PR TITLE
Add option java_home_pillar to set pillar syntax to search for java_home

### DIFF
--- a/hadoop/settings.sls
+++ b/hadoop/settings.sls
@@ -153,7 +153,8 @@
 {%- set dfsadmin_cmd = alt_home + '/bin/hdfs dfsadmin' %}
 {%- endif %}
 
-{%- set java_home        = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/lib/java')) %}
+{%- set java_home_pillar = p.get('java_home_pillar', 'java:java_home') %}
+{%- set java_home        = salt['grains.get']('java_home', salt['pillar.get'](java_home_pillar, '/usr/lib/java')) %}
 {%- set config_core_site = gc.get('core-site', pc.get('core-site', {})) %}
 
 {%- set hadoop = {} %}


### PR DESCRIPTION
There is a new entry in hadoop pillar called "java_home_pillar" that have a pillar.get syntax value to look for java_home on other parts of the pillar, by default it will look for java:java_home. This will permit more flexibility of someone has already a java pillar config and avoids the need to create a java_home value on the top level pillar as before.

``` yaml
java:
  java_home: /usr/lib/java/jdk1.8.0_102
hadoop:
  version: apache-2.7.3
  prefix: /usr/lib/hadoop/hadoop-2.7.3
  java_home_pillar: 'java:java_home'
  config:
    directory: /etc/hadoop
```
Tested on 2016.3.3 (Boron)