### PR TITLE
Add hadoop 3 and multicluster support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,26 @@ Which services end up running on a given host will again depend on the role(s) a
 - hadoop_master will run the hadoop-resourcemanager service
 - hadoop_slave will run the hadoop-nodemanager service
 
+``hadoop.hdfs.uninstall``
+---------------
+
+Stops the hdfs services and uninstalls the hdfs service configuration. Removes hdfs data from local disks.
+
+``hadoop.mapred.uninstall``
+---------------
+
+Uninstalls the mapreduce service scripts and configuration. Removes mapred data from local disks.
+
+``hadoop.yarn.uninstall``
+---------------
+
+Uninstalls the yarn daemon scripts and configuration. Removes yarn data from local disks.
+
+``hadoop.uninstall``
+---------------
+
+Uninstalls all Hadoop services and configurations.
+
 Formula Dependencies
 ====================
 

--- a/README_HA.rst
+++ b/README_HA.rst
@@ -93,7 +93,7 @@ Since this feature is more complex than the already distributed Hadoop architect
   b) Initialize Zookeeper for namenode HA (hdfs zkfc -formatZK)
   c) Start namenode service as usual (service hadoop-namenode start)
   d) Start the zookeeper fencing service (service hadoop-zkfc start)
-8. On the designated "second" namenode (to become the standby member):
+8. On the designated "second" namenodes (to become the standby members):
   a) Prepare HDFS namenode metadata (hdfs namenode -prepareStandby)
   b) Start namenode service as usual (service hadoop-namenode start)
   c) Start the zookeeper fencing service (service hadoop-zkfc start)

--- a/hadoop/conf/hadoop-env.sh
+++ b/hadoop/conf/hadoop-env.sh
@@ -3,6 +3,8 @@ export HADOOP_PREFIX={{ hadoop_home }}
 export HADOOP_CONF_DIR={{ hadoop_config }}
 export PATH=$HADOOP_PREFIX/bin:$HADOOP_PREFIX/sbin:${JAVA_HOME}/bin:$PATH
 
+# export HADOOP_COMMON_LIB_NATIVE_DIR=/usr/lib/hadoop/lib/native/
+
 export HADOOP_HEAPSIZE=1024
 
 export JMX_OPTS=" -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1"

--- a/hadoop/conf/mapred/mapred-site.xml
+++ b/hadoop/conf/mapred/mapred-site.xml
@@ -7,7 +7,6 @@
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 
 <configuration>
-
 {%- if major == '1' %}
     <property>
         <name>mapred.job.tracker</name>

--- a/hadoop/conf/yarn/yarn-site.xml
+++ b/hadoop/conf/yarn/yarn-site.xml
@@ -7,31 +7,91 @@
 <?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
 
 <configuration>
+{%- if yarn.resourcemanager_hosts|count() > 1 %}
+
+{%- from 'zookeeper/settings.sls' import zk with context %}
+
+    <property>
+      <name>yarn.resourcemanager.ha.enabled</name>
+      <value>true</value>
+    </property>
+    
+    <property>
+      <name>yarn.resourcemanager.cluster-id</name>
+      <value>{{yarn.ha_cluster_id}}</value>
+    </property>
+    
+    <property>
+      <name>yarn.resourcemanager.ha.rm-ids</name>
+        <value>
+{%- for i in range(yarn.resourcemanager_hosts|count()) -%}
+rm{{loop.index}}{{ '' if loop.last else ',' }}
+{%- endfor -%}</value>
+    </property>
+    
+    <property>
+      <name>yarn.resourcemanager.zk-address</name>
+      <value>{{ zk.connection_string }}</value>
+    </property>
+    
+{% for resourcemanager_host in yarn.resourcemanager_hosts %}
+
+    <property>
+        <name>yarn.resourcemanager.scheduler.address.rm{{loop.index}}</name>
+        <value>{{ resourcemanager_host }}:{{ yarn.scheduler_port }}</value>
+    </property>
+     
+    <property>
+        <name>yarn.resourcemanager.resource-tracker.address.rm{{loop.index}}</name>
+        <value>{{ resourcemanager_host }}:{{ yarn.resourcetracker_port }}</value>
+    </property>
+     
+    <property>
+        <name>yarn.resourcemanager.address.rm{{loop.index}}</name>
+        <value>{{ resourcemanager_host }}:{{ yarn.resourcemanager_port }}</value>
+    </property>
+     
+    <property>
+        <name>yarn.resourcemanager.admin.address.rm{{loop.index}}</name>
+        <value>{{ resourcemanager_host }}:{{ yarn.resourcemanager_admin_port }}</value>
+    </property>
+     
+    <property>
+        <name>yarn.resourcemanager.webapp.address.rm{{loop.index}}</name>
+        <value>{{ resourcemanager_host }}:{{ yarn.resourcemanager_webapp_port }}</value>
+    </property>
+
+{%- endfor -%}
+    
+{%- else -%}
+
     <property>
         <name>yarn.resourcemanager.scheduler.address</name>
-        <value>{{ yarn.resourcemanager_host }}:{{ yarn.scheduler_port }}</value>
+        <value>{{ yarn.resourcemanager_hosts|first() }}:{{ yarn.scheduler_port }}</value>
     </property>
      
     <property>
         <name>yarn.resourcemanager.resource-tracker.address</name>
-        <value>{{ yarn.resourcemanager_host }}:{{ yarn.resourcetracker_port }}</value>
+        <value>{{ yarn.resourcemanager_hosts|first() }}:{{ yarn.resourcetracker_port }}</value>
     </property>
      
     <property>
         <name>yarn.resourcemanager.address</name>
-        <value>{{ yarn.resourcemanager_host }}:{{ yarn.resourcemanager_port }}</value>
+        <value>{{ yarn.resourcemanager_hosts|first() }}:{{ yarn.resourcemanager_port }}</value>
     </property>
      
     <property>
         <name>yarn.resourcemanager.admin.address</name>
-        <value>{{ yarn.resourcemanager_host }}:{{ yarn.resourcemanager_admin_port }}</value>
+        <value>{{ yarn.resourcemanager_hosts|first() }}:{{ yarn.resourcemanager_admin_port }}</value>
     </property>
      
     <property>
         <name>yarn.resourcemanager.webapp.address</name>
-        <value>{{ yarn.resourcemanager_host }}:{{ yarn.resourcemanager_webapp_port }}</value>
+        <value>{{ yarn.resourcemanager_hosts|first() }}:{{ yarn.resourcemanager_webapp_port }}</value>
     </property>
 
+{%- endif -%}
+    
     <property>
         <name>yarn.nodemanager.address</name>
         <value>0.0.0.0:{{ yarn.nodemanager_port }}</value>

--- a/hadoop/files/hadoop.init
+++ b/hadoop/files/hadoop.init
@@ -44,6 +44,10 @@ if [ -f /etc/default/hadoop ]; then
   . /etc/default/hadoop
 fi
 
+if [ -f /etc/init.d/functions ]; then
+  . /etc/init.d/functions
+fi
+
 if [ -f /etc/default/mapred-{{ hadoop_user }}-{{ hadoop_svc }} ] ; then
   . /etc/default/mapred-{{ hadoop_user }}-{{ hadoop_svc }}
 fi

--- a/hadoop/files/hadoop.init
+++ b/hadoop/files/hadoop.init
@@ -68,9 +68,9 @@ SLEEP_TIME=5
 PROC_NAME="java"
 
 {%- if hadoop_major == 1 %}
-{%- set bindir='bin' %}
+  {%- set bindir='bin' %}
 {%- else %}
-{%- set bindir='sbin' %}
+  {%- set bindir='sbin' %}
 {%- endif %}
 
 DAEMON="hadoop-{{ hadoop_user }}-{{ hadoop_svc }}"
@@ -94,6 +94,10 @@ EXEC_PATH="{{ hadoop_home }}/{{ bindir }}/yarn-daemon.sh"
 {%- else %}
 PIDFILE="${PIDDIR}/hadoop-{{ hadoop_user }}-{{ hadoop_svc }}.pid"
 EXEC_PATH="{{ hadoop_home }}/{{ bindir }}/hadoop-daemon.sh"
+{%- endif %}
+
+{%- if hadoop_major > 2 %}
+PIDFILE="${PIDDIR}/hadoop-{{ hadoop_user }}-{{ hadoop_svc }}.pid"
 {%- endif %}
 
 start() {

--- a/hadoop/files/hadoop.service
+++ b/hadoop/files/hadoop.service
@@ -1,7 +1,7 @@
 {%- if hadoop_major == 1 %}
-{%- set bindir='bin' %}
+  {%- set bindir='bin' %}
 {%- else %}
-{%- set bindir='sbin' %}
+  {%- set bindir='sbin' %}
 {%- endif %}
 
 {%- set piddir="/var/run/hadoop" %}
@@ -16,6 +16,10 @@
 {%- else %}
   {%- set pidfile=piddir+"/hadoop-"+hadoop_user+"-"+hadoop_svc+".pid" %}
   {%- set exec_path=hadoop_home+"/"+bindir+"/hadoop-daemon.sh" %}
+{%- endif %}
+
+{%- if hadoop_major > 2 %}
+  {%- set pidfile=piddir+"/hadoop-"+hadoop_user+"-"+hadoop_svc+".pid" %}
 {%- endif %}
 
 [Unit]

--- a/hadoop/files/hadoop.service
+++ b/hadoop/files/hadoop.service
@@ -31,9 +31,12 @@ Requires=network-online.target
 User={{ hadoop_user }}
 Group=hadoop
 Type=forking
+RuntimeDirectory=hadoop
+RuntimeDirectoryMode=775
 ExecStart={{ exec_path }} --config {{ conf_dir }} start {{ hadoop_svc }}
 ExecStop={{ exec_path }} --config {{ conf_dir }} stop {{ hadoop_svc }}
 TimeoutStartSec=2min
+Restart=on-failure
 PIDFile={{ pidfile }}
 
 [Install]

--- a/hadoop/files/hadoop.service
+++ b/hadoop/files/hadoop.service
@@ -1,0 +1,36 @@
+{%- if hadoop_major == 1 %}
+{%- set bindir='bin' %}
+{%- else %}
+{%- set bindir='sbin' %}
+{%- endif %}
+
+{%- set piddir="/var/run/hadoop" %}
+{%- set conf_dir="/etc/hadoop/conf" %}
+
+{%- if hadoop_svc == 'historyserver' %}
+  {%- set pidfile=piddir+"/mapred-"+hadoop_user+"-"+hadoop_svc+".pid" %}
+  {%- set exec_path=hadoop_home+"/"+bindir+"/mr-jobhistory-daemon.sh" %}
+{%- elif hadoop_user == 'yarn' %}
+  {%- set pidfile=piddir+"/yarn-"+hadoop_user+"-"+hadoop_svc+".pid" %}
+  {%- set exec_path=hadoop_home+"/"+bindir+"/yarn-daemon.sh" %}
+{%- else %}
+  {%- set pidfile=piddir+"/hadoop-"+hadoop_user+"-"+hadoop_svc+".pid" %}
+  {%- set exec_path=hadoop_home+"/"+bindir+"/hadoop-daemon.sh" %}
+{%- endif %}
+
+[Unit]
+Description=Hadoop DFS {{ hadoop_svc }}
+After=syslog.target network.target remote-fs.target nss-lookup.target network-online.target
+Requires=network-online.target
+
+[Service]
+User={{ hadoop_user }}
+Group=hadoop
+Type=forking
+ExecStart={{ exec_path }} --config {{ conf_dir }} start {{ hadoop_svc }}
+ExecStop={{ exec_path }} --config {{ conf_dir }} stop {{ hadoop_svc }}
+TimeoutStartSec=2min
+PIDFile={{ pidfile }}
+
+[Install]
+WantedBy=multi-user.target

--- a/hadoop/files/hadoop.sh.jinja
+++ b/hadoop/files/hadoop.sh.jinja
@@ -6,3 +6,5 @@ export HADOOP_COMMON_HOME={{ alt_home }}
 export HADOOP_HDFS_HOME={{ alt_home }}
 export HADOOP_MAPRED_HOME={{ alt_home }}
 export HADOOP_YARN_HOME={{ alt_home }}
+# export HADOOP_COMMON_LIB_NATIVE_DIR={{ alt_home }}/lib/native
+# export HADOOP_OPTS="-Djava.library.path={{ alt_home }}/lib/native"

--- a/hadoop/hdfs/ha_namenode.sls
+++ b/hadoop/hdfs/ha_namenode.sls
@@ -44,7 +44,7 @@ bootstrap-secondary-namenode:
 
 {%- if hdfs.is_primary_namenode or hdfs.is_secondary_namenode %}
 
-hdfs-services:
+hdfs-ha-services:
   service.running:
     - enable: True
     - names:

--- a/hadoop/hdfs/init.sls
+++ b/hadoop/hdfs/init.sls
@@ -108,8 +108,13 @@ format-namenode:
     - unless: test -d {{ test_folder }}
 {%- endif %}
 
-/etc/init.d/hadoop-namenode:
+hadoop-namenode-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-namenode.service
+{% else %}
+    - name: /etc/init.d/hadoop-namenode
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -120,10 +125,23 @@ format-namenode:
       hadoop_user: hdfs
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-namenode-service
+    - watch_in:
+      - service: hdfs-services
+{% endif %}
 
 {%- if hdfs.namenode_count == 1 %}
-/etc/init.d/hadoop-secondarynamenode:
+hadoop-secondarynamenode-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-secondarynamenode.service
+{% else %}
+    - name: /etc/init.d/hadoop-secondarynamenode
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -134,9 +152,22 @@ format-namenode:
       hadoop_user: hdfs
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-secondarynamenode-service
+    - watch_in:
+      - service: hdfs-nn-services
+{% endif %}
 {%- else %}
-/etc/init.d/hadoop-zkfc:
+hadoop-zkfc-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-zkfc.service
+{% else %}
+    - name: /etc/init.d/hadoop-zkfc
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -147,12 +178,24 @@ format-namenode:
       hadoop_user: hdfs
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-zkfc-service
+{% endif %}
 {% endif %}
 {% endif %}
 
 {% if hdfs.is_datanode %}
-/etc/init.d/hadoop-datanode:
+
+hadoop-datanode-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-datanode.service
+{% else %}
+    - name: /etc/init.d/hadoop-datanode
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -163,11 +206,24 @@ format-namenode:
       hadoop_user: hdfs
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-datanode-service
+    - watch_in:
+      - service: hdfs-services
+{% endif %}
 {% endif %}
 
 {% if hdfs.is_journalnode %}
-/etc/init.d/hadoop-journalnode:
+hadoop-journalnode-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-journalnode.service
+{% else %}
+    - name: /etc/init.d/hadoop-journalnode
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -178,6 +234,14 @@ format-namenode:
       hadoop_user: hdfs
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-journalnode-service
+    - watch_in:
+      - service: hdfs-services
+{% endif %}
 {% endif %}
 
 {% if hdfs.is_namenode and hdfs.namenode_count == 1 %}

--- a/hadoop/hdfs/init.sls
+++ b/hadoop/hdfs/init.sls
@@ -130,8 +130,10 @@ hadoop-namenode-service:
     - name: service.systemctl_reload
     - watch:
       - file: hadoop-namenode-service
+{% if hdfs.is_datanode or hdfs.is_journalnode %}
     - watch_in:
       - service: hdfs-services
+{% endif %}
 {% endif %}
 
 {%- if hdfs.namenode_count == 1 %}

--- a/hadoop/hdfs/settings.sls
+++ b/hadoop/hdfs/settings.sls
@@ -1,3 +1,5 @@
+{%- from 'hadoop/settings.sls' import hadoop with context %}
+
 {%- set p  = salt['pillar.get']('hdfs', {}) %}
 {%- set pc = p.get('config', {}) %}
 {%- set g  = salt['grains.get']('hdfs', {}) %}
@@ -76,6 +78,15 @@
 {%- endif %}
 
 {%- set namenode_count = namenode_hosts|count() %}
+
+{%- if namenode_count > 1 and hadoop.major_version == '1' %}
+  {%- set namenode_hosts = [namenode_hosts[0]] %}
+  {%- set namenode_count = namenode_hosts|count() %}
+{%- elif namenode_count > 2 and hadoop.major_version == '2' %}
+  {%- set namenode_hosts = [namenode_hosts[0], namenode_hosts[1]] %}
+  {%- set namenode_count = namenode_hosts|count() %}
+{%- endif %}
+
 {%- if namenode_count > 0 %}
   {%- set namenode_host = namenode_hosts|first()|join() %}
 {%- endif %}
@@ -149,7 +160,7 @@
 
 {%- set is_primary_namenode      = is_primary_namenode or primary_namenode_host in minion_hosts %}
 
-{%- set is_secondary_namenode    = is_secondary_namenode or ( is_namenode and not is_primary_namenode ) %}
+{%- set is_secondary_namenode    = ( is_secondary_namenode or is_namenode ) and not is_primary_namenode %}
 
 {%- set restart_on_config_change = pc.get('restart_on_config_change', False) %}
 

--- a/hadoop/hdfs/settings.sls
+++ b/hadoop/hdfs/settings.sls
@@ -3,41 +3,42 @@
 {%- set g  = salt['grains.get']('hdfs', {}) %}
 {%- set gc = g.get('config', {}) %}
 
-{%- set namenode_target     = g.get('namenode_target', p.get('namenode_target', 'roles:hadoop_master')) %}
-{%- set primary_namenode_target   = g.get('primary_namenode_target', p.get('primary_namenode_target', 'roles:hdfs_namenode1')) %}
-{%- set secondary_namenode_target = g.get('secondary_namenode_target', p.get('secondary_namenode_target', 'roles:hdfs_namenode2')) %}
-{%- set datanode_target     = g.get('datanode_target', p.get('datanode_target', 'roles:hadoop_slave')) %}
-{%- set journalnode_target  = g.get('journalnode_target', p.get('journalnode_target', 'roles:hdfs_journalnode')) %}
+{%- set namenode_target              = g.get('namenode_target', p.get('namenode_target', 'roles:hadoop_master')) %}
+{%- set primary_namenode_target      = g.get('primary_namenode_target', p.get('primary_namenode_target', 'roles:hdfs_namenode1')) %}
+{%- set secondary_namenode_target    = g.get('secondary_namenode_target', p.get('secondary_namenode_target', 'roles:hdfs_namenode2')) %}
+{%- set datanode_target              = g.get('datanode_target', p.get('datanode_target', 'roles:hadoop_slave')) %}
+{%- set journalnode_target           = g.get('journalnode_target', p.get('journalnode_target', 'roles:hdfs_journalnode')) %}
 # this is a deliberate duplication as to not re-import hadoop/settings multiple times
-{%- set targeting_method    = salt['grains.get']('hadoop:targeting_method', salt['pillar.get']('hadoop:targeting_method', 'grain')) %}
+{%- set targeting_method             = salt['grains.get']('hadoop:targeting_method', salt['pillar.get']('hadoop:targeting_method', 'grain')) %}
 
-{%- set namenode_port         = gc.get('namenode_port', pc.get('namenode_port', '8020')) %}
-{%- set namenode_http_port    = gc.get('namenode_http_port', pc.get('namenode_http_port', '50070')) %}
+{%- set namenode_port                = gc.get('namenode_port', pc.get('namenode_port', '8020')) %}
+{%- set namenode_http_port           = gc.get('namenode_http_port', pc.get('namenode_http_port', '50070')) %}
 {%- set secondarynamenode_http_port  = gc.get('secondarynamenode_http_port', pc.get('secondarynamenode_http_port', '50090')) %}
-{%- set local_disks           = salt['grains.get']('hdfs_data_disks', ['/data']) %}
-{%- set load                  = salt['grains.get']('hdfs_load', salt['pillar.get']('hdfs_load', {})) %}
-{%- set ha_cluster_id         = salt['grains.get']('ha_cluster_id', salt['pillar.get']('ha_cluster_id', None)) %}
-{%- set ha_namenode_port      = gc.get('ha_namenode_port', pc.get('ha_namenode_port', namenode_port)) %}
-{%- set ha_journal_port       = gc.get('ha_journal_port', pc.get('ha_journal_port', '8485')) %}
-{%- set ha_namenode_http_port = gc.get('ha_namenode_http_port', pc.get('ha_namenode_http_port', namenode_http_port)) %}
+{%- set local_disks                  = salt['grains.get']('hdfs_data_disks', ['/data']) %}
+{%- set load                         = salt['grains.get']('hdfs_load', salt['pillar.get']('hdfs_load', {})) %}
+{%- set ha_cluster_id                = salt['grains.get']('ha_cluster_id', salt['pillar.get']('ha_cluster_id', None)) %}
+{%- set ha_namenode_port             = gc.get('ha_namenode_port', pc.get('ha_namenode_port', namenode_port)) %}
+{%- set ha_journal_port              = gc.get('ha_journal_port', pc.get('ha_journal_port', '8485')) %}
+{%- set ha_namenode_http_port        = gc.get('ha_namenode_http_port', pc.get('ha_namenode_http_port', namenode_http_port)) %}
 
-{%- set config_hdfs_site = gc.get('hdfs-site', pc.get('hdfs-site', {})) %}
+{%- set config_hdfs_site             = gc.get('hdfs-site', pc.get('hdfs-site', {})) %}
 
-{%- set minion_hosts          = [salt['network.get_hostname'](),
-                                 grains['fqdn'],
-                                 grains['nodename']] + salt['network.ip_addrs']() %}
+{%- set minion_hosts                 = [salt['network.get_hostname'](),
+                                        grains['fqdn'],
+                                        grains['nodename']] + salt['network.ip_addrs']() %}
 
-{%- set is_clusters           = True if p.get('clusters') else False %}                               
+{%- set is_clusters                  = True if p.get('clusters') else False %}                               
 
-{%- set pillar_cluster_id = [] %}
+{%- set pillar_cluster_id            = [] %}
 
 {%- if is_clusters and ha_cluster_id == None %}
   {%- for cluster_name, cluster_value in p.clusters.items() %}
+    {%- set hdfs_hosts = cluster_value.get('namenode_hosts', []) + 
+                         cluster_value.get('datanode_hosts', []) + 
+                         cluster_value.get('journalnode_hosts', []) %}  
+    {%- do hdfs_hosts.append(cluster_value.get('primary_namenode_host', '')) %}
     {%- for minion_host in minion_hosts %}
-      {%- if minion_host in cluster_value.get('namenode_hosts', []) or
-             minion_host in cluster_value.get('datanode_hosts', []) or 
-             minion_host in cluster_value.get('journalnode_hosts', []) or
-             minion_host == cluster_value.get('primary_namenode_host', '') %}
+      {%- if minion_host in hdfs_hosts %}
         {%- do pillar_cluster_id.append(cluster_name) %}
         {%- break %}
       {%- endif %}
@@ -93,20 +94,24 @@
 {%- endif %}
 # Todo: this might be a candidate for pillars/grains
 # {%- set tmp_root        = local_disks|first() %}
-{%- set tmp_dir               = '/tmp' %}
+{%- set tmp_dir                  = '/tmp' %}
 
-{%- set replicas              = gc.get('replication', pc.get('replication', datanode_count % 4 if datanode_count < 4 else 3 )) %}
+{%- set replicas                 = gc.get('replication', pc.get('replication', datanode_count % 4 if datanode_count < 4 else 3 )) %}
 
-{%- set is_namenode           = salt['match.' ~ targeting_method](namenode_target) %}
-{%- set is_primary_namenode   = salt['match.' ~ targeting_method](primary_namenode_target) %}
-{%- set is_secondary_namenode = salt['match.' ~ targeting_method](secondary_namenode_target) %}
-{%- set is_journalnode        = salt['match.' ~ targeting_method](journalnode_target) %}
-{%- set is_datanode           = salt['match.' ~ targeting_method](datanode_target) %}
+{%- set is_namenode              = salt['match.' ~ targeting_method](namenode_target) %}
+{%- set is_primary_namenode      = salt['match.' ~ targeting_method](primary_namenode_target) %}
+{%- set is_secondary_namenode    = salt['match.' ~ targeting_method](secondary_namenode_target) %}
+{%- set is_journalnode           = salt['match.' ~ targeting_method](journalnode_target) %}
+{%- set is_datanode              = salt['match.' ~ targeting_method](datanode_target) %}
+
+{%- set is_datanode_in_pillar    = [] %}
+{%- set is_namenode_in_pillar    = [] %}
+{%- set is_journalnode_in_pillar = [] %}
 
 {%- if not is_datanode %}
   {%- for minion_host in minion_hosts %}
     {%- if minion_host in datanode_hosts %}
-      {%- set is_datanode_in_pillar = True %}
+      {%- do is_datanode_in_pillar.append(True) %}
       {% break %}
     {%- endif %}
   {%- endfor %}
@@ -115,7 +120,7 @@
 {%- if not is_namenode %}
   {%- for minion_host in minion_hosts %}
     {%- if minion_host in namenode_hosts %}
-      {%- set is_namenode_in_pillar = True %}
+      {%- do is_namenode_in_pillar.append(True) %}
       {% break %}
     {%- endif %}
   {%- endfor %}
@@ -124,27 +129,27 @@
 {%- if not is_journalnode %}
   {%- for minion_host in minion_hosts %}
     {%- if minion_host in journalnode_hosts %}
-      {%- set is_journalnode_in_pillar = True %}
+      {%- do is_journalnode_in_pillar.append(True) %}
       {% break %}
     {%- endif %}
   {%- endfor %}
 {%- endif %}
 
-{%- if is_namenode_in_pillar is defined %}
-  {%- set is_namenode = is_namenode or is_namenode_in_pillar %}
+{%- if is_namenode_in_pillar %}
+  {%- set is_namenode = True %}
 {%- endif %}
 
-{%- if is_journalnode_in_pillar is defined %}
-  {%- set is_journalnode = is_journalnode or is_journalnode_in_pillar %}
+{%- if is_journalnode_in_pillar %}
+  {%- set is_journalnode = True %}
 {%- endif %}
 
-{%- if is_datanode_in_pillar is defined %}
-  {%- set is_datanode = is_datanode or is_datanode_in_pillar %}
+{%- if is_datanode_in_pillar %}
+  {%- set is_datanode = True %}
 {%- endif %}
 
-{%- set is_primary_namenode = is_primary_namenode or primary_namenode_host in minion_hosts %}
+{%- set is_primary_namenode      = is_primary_namenode or primary_namenode_host in minion_hosts %}
 
-{%- set is_secondary_namenode = is_secondary_namenode or ( is_namenode and not is_primary_namenode ) %}
+{%- set is_secondary_namenode    = is_secondary_namenode or ( is_namenode and not is_primary_namenode ) %}
 
 {%- set restart_on_config_change = pc.get('restart_on_config_change', False) %}
 

--- a/hadoop/hdfs/uninstall.sls
+++ b/hadoop/hdfs/uninstall.sls
@@ -1,0 +1,57 @@
+{%- from 'hadoop/settings.sls' import hadoop with context %}
+{%- from 'hadoop/hdfs/settings.sls' import hdfs with context %}
+
+hadoop-dfs-stopped:
+  service.dead:
+    - names: 
+      - hadoop-namenode
+      - hadoop-secondarynamenode
+      - hadoop-zkfc
+      - hadoop-datanode
+      - hadoop-journalnode
+    - enable: False
+
+hadoop-dfs-services-removed:
+  file.absent:
+    - names:
+      - /etc/systemd/system/hadoop-namenode.service
+      - /etc/init.d/hadoop-namenode
+      - /etc/systemd/system/hadoop-secondarynamenode.service
+      - /etc/init.d/hadoop-secondarynamenode
+      - /etc/systemd/system/hadoop-zkfc.service
+      - /etc/init.d/hadoop-zkfc
+      - /etc/systemd/system/hadoop-datanode.service
+      - /etc/init.d/hadoop-datanode
+      - /etc/systemd/system/hadoop-journalnode.service
+      - /etc/init.d/hadoop-journalnode
+    - require:
+      - service: hadoop-dfs-stopped
+{%- if grains.get('systemd') %}
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: hadoop-dfs-services-removed
+{%- endif %}
+
+hadoop-dfs-files-removed:
+  file.absent:
+    - names:
+      - {{ hadoop.alt_config }}/dfs.hosts.exclude
+      - {{ hadoop.alt_config }}/dfs.hosts
+      - {{ hadoop.alt_config }}/slaves
+      - {{ hadoop.alt_config }}/masters
+      - {{ hadoop.alt_config }}/hdfs-site.xml
+      - {{ hadoop.alt_config }}/core-site.xml
+
+{%- set hdfs_disks = hdfs.local_disks %}
+{%- set test_folder = hdfs_disks|first() + '/hdfs/nn/current' %}
+
+hadoop-dfs-data-removed:
+  file.absent:
+    - names:
+{% for disk in hdfs_disks %}
+      - {{ disk }}/hdfs
+{% endfor %}
+{%- if hdfs.tmp_dir != '/tmp' %}
+      {{ hdfs.tmp_dir }}
+{% endif %}

--- a/hadoop/init.sls
+++ b/hadoop/init.sls
@@ -50,71 +50,36 @@ unpack-hadoop-dist:
     - archive_format: tar
     - if_missing: {{ hadoop['real_home'] }}
     - require_in:
-      - alternatives: hadoop-home-link
-      - alternatives: hadoop-bin-link
-      - alternatives: hdfs-bin-link
-      - alternatives: mapred-bin-link
-      - alternatives: yarn-bin-link
+      - file: hadoop-home-link
+      - file: hadoop-bin-link
+      - file: hdfs-bin-link
+      - file: mapred-bin-link
+      - file: yarn-bin-link
 
 hadoop-home-link:
-  alternatives.install:
-    - link: {{ hadoop['alt_home'] }}
-    - path: {{ hadoop['real_home'] }}
-    - priority: 30
-    - onlyif: test -d {{ hadoop['real_home'] }} && test ! -L {{ hadoop['alt_home'] }}
   file.symlink:
     - name: {{ hadoop['alt_home'] }}
     - target: {{ hadoop['real_home'] }}
-    - require:
-      - alternatives: hadoop-home-link
-      
+
 hadoop-bin-link:
-  alternatives.install:
-    - link: /usr/bin/hadoop
-    - path: {{ hadoop['alt_home'] }}/bin/hadoop
-    - priority: 30
-    - onlyif: test -f {{ hadoop['alt_home'] }}/bin/hadoop && test ! -L /usr/bin/hadoop
   file.symlink:
     - name: /usr/bin/hadoop
     - target: {{ hadoop['alt_home'] }}/bin/hadoop
-    - require:
-      - alternatives: hadoop-bin-link
       
 hdfs-bin-link:
-  alternatives.install:
-    - link: /usr/bin/hdfs
-    - path: {{ hadoop['alt_home'] }}/bin/hdfs
-    - priority: 30
-    - onlyif: test -f {{ hadoop['alt_home'] }}/bin/hdfs && test ! -L /usr/bin/hdfs
   file.symlink:
     - name: /usr/bin/hdfs
     - target: {{ hadoop['alt_home'] }}/bin/hdfs
-    - require:
-      - alternatives: hdfs-bin-link
       
 mapred-bin-link:
-  alternatives.install:
-    - link: /usr/bin/mapred
-    - path: {{ hadoop['alt_home'] }}/bin/mapred
-    - priority: 30
-    - onlyif: test -f {{ hadoop['alt_home'] }}/bin/mapred && test ! -L /usr/bin/mapred
   file.symlink:
     - name: /usr/bin/mapred
     - target: {{ hadoop['alt_home'] }}/bin/mapred
-    - require:
-      - alternatives: mapred-bin-link
       
 yarn-bin-link:
-  alternatives.install:
-    - link: /usr/bin/yarn
-    - path: {{ hadoop['alt_home'] }}/bin/yarn
-    - priority: 30
-    - onlyif: test -f {{ hadoop['alt_home'] }}/bin/yarn && test ! -L /usr/bin/yarn
   file.symlink:
     - name: /usr/bin/yarn
     - target: {{ hadoop['alt_home'] }}/bin/yarn
-    - require:
-      - alternatives: yarn-bin-link
       
 {%- if hadoop.cdhmr1 %}
 
@@ -194,18 +159,11 @@ move-hadoop-dist-conf:
       - cmd: move-hadoop-dist-conf
 
 hadoop-conf-link:
-  alternatives.install:
-    - link: {{ hadoop['alt_config'] }}
-    - path: {{ hadoop['real_config'] }}
-    - priority: 30
-    - onlyif: test -d {{ hadoop['real_config'] }} && test ! -L {{ hadoop['alt_config'] }}
-    - require:
-      - file: {{ hadoop['real_config'] }}
   file.symlink:
     - name: {{ hadoop['alt_config'] }}
     - target: {{ hadoop['real_config'] }}
     - require:
-      - alternatives: hadoop-conf-link
+      - file: {{ hadoop['real_config'] }}
       
 {{ hadoop['real_config'] }}/log4j.properties:
   file.copy:
@@ -215,7 +173,7 @@ hadoop-conf-link:
     - mode: 644
     - require:
       - file: {{ hadoop['real_config'] }}
-      - alternatives: hadoop-conf-link
+      - file: hadoop-conf-link
 
 {{ hadoop['real_config'] }}/hadoop-env.sh:
   file.managed:

--- a/hadoop/mapred/init.sls
+++ b/hadoop/mapred/init.sls
@@ -50,8 +50,13 @@
 {%- if hadoop['major_version'] == '1' %}
 
 {% if mapred.is_jobtracker %}
-/etc/init.d/hadoop-jobtracker:
+hadoop-jobtracker-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-jobtracker.service
+{% else %}
+    - name: /etc/init.d/hadoop-jobtracker
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -62,15 +67,28 @@
       hadoop_user: mapred
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
-
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-jobtracker-service
+    - watch_in:
+      - service: hadoop-jobtracker
+{% endif %}
+      
 hadoop-jobtracker:
   service.running:
     - enable: True
 {%- endif %}
 
 {% if mapred.is_tasktracker %}
-/etc/init.d/hadoop-tasktracker:
+hadoop-tasktracker-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-tasktracker.service
+{% else %}
+    - name: /etc/init.d/hadoop-tasktracker
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -81,6 +99,14 @@ hadoop-jobtracker:
       hadoop_user: mapred
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-tasktracker-service
+    - watch_in:
+      - service: hadoop-tasktracker
+{% endif %}
 
 hadoop-tasktracker:
   service.running:

--- a/hadoop/mapred/settings.sls
+++ b/hadoop/mapred/settings.sls
@@ -1,3 +1,4 @@
+{%- from 'hadoop/hdfs/settings.sls' import hdfs with context %}
 {% set p  = salt['pillar.get']('mapred', {}) %}
 {% set pc = p.get('config', {}) %}
 {% set g  = salt['grains.get']('mapred', {}) %}
@@ -13,13 +14,74 @@
 {%- set jobtracker_target = g.get('jobtracker_target', p.get('jobtracker_target', 'roles:hadoop_master')) %}
 {%- set tasktracker_target = g.get('tasktracker_target', p.get('tasktracker_target', 'roles:hadoop_slave')) %}
 {%- set targeting_method = salt['grains.get']('hadoop:targeting_method', salt['pillar.get']('hadoop:targeting_method', 'grain')) %}
+{%- set ha_cluster_id               = salt['grains.get']('ha_cluster_id', salt['pillar.get']('ha_cluster_id', None)) %}
 
-{%- set jobtracker_host  = g.get('jobtracker_host', p.get('jobtracker_host', salt['mine.get'](jobtracker_target, 'network.interfaces', expr_form=targeting_method)|first)) %}
+{%- set minion_hosts                = [salt['network.get_hostname'](),
+                                       grains['fqdn'],
+                                       grains['nodename']] + salt['network.ip_addrs']() %}
+
+{%- set is_clusters           = True if p.get('clusters') else False %} 
+{%- set pillar_cluster_id = [] %}
+
+{%- if is_clusters and ha_cluster_id == None %}
+  {%- for cluster_name, cluster_value in p.clusters.items() %}
+    {%- for minion_host in minion_hosts %}
+      {%- if minion_host in cluster_value.get('tasktracker_hosts', []) or
+             minion_host == cluster_value.get('jobtracker_host', '') %}
+        {%- do pillar_cluster_id.append(cluster_name) %}
+        {%- break %}
+      {%- endif %}
+    {%- endfor %}
+    {%- if pillar_cluster_id %}
+      {%- break %}
+    {%- endif %}
+  {%- endfor %}
+{%- endif %}
+
+{%- if pillar_cluster_id %}
+  {%- set ha_cluster_id = pillar_cluster_id[0] %}
+{%- endif %}
+
+{%- if is_clusters and ha_cluster_id != None %}
+  {%- set jobtracker_host = p.clusters.get(ha_cluster_id, {}).get('jobtracker_host', '') %}
+  {%- set tasktracker_hosts = p.clusters.get(ha_cluster_id, {}).get('tasktracker_hosts', []) %}
+  {%- if p.get(ha_cluster_id, {}).get('tasktrackers_on_datanodes', False) %}
+    {%- set tasktracker_hosts = tasktracker_hosts + hdfs.datanode_hosts %}
+  {%- endif %}
+{%- else %}
+  {%- set jobtracker_host  = g.get('jobtracker_host', p.get('jobtracker_host', None)) %}
+  {%- if jobtracker_host == None %}
+    {%- set jobtracker_host = salt['mine.get'](jobtracker_target, 'network.interfaces', expr_form=targeting_method) %}
+    {%- if jobtracker_host | count() > 0 %}
+      {%- set jobtracker_host  = jobtracker_host|first() %}
+    {%- endif %}
+  {%- endif %}
+  {%- set tasktracker_hosts = g.get('tasktracker_hosts', p.get('tasktracker_hosts', [])) %}
+  {%- if p.get('tasktrackers_on_datanodes', False) %}
+    {%- set tasktracker_hosts = tasktracker_hosts + hdfs.datanode_hosts %}
+  {%- endif %}
+{%- endif %}
+
 {%- set local_disks     = salt['grains.get']('mapred_data_disks', ['/data']) %}
 {%- set config_mapred_site = gc.get('mapred-site', pc.get('mapred-site', {})) %}
 
 {%- set is_jobtracker = salt['match.' ~ targeting_method](jobtracker_target) %}
 {%- set is_tasktracker = salt['match.' ~ targeting_method](tasktracker_target) %}
+
+{%- if not is_tasktracker %}
+  {%- for minion_host in minion_hosts %}
+    {%- if minion_host in tasktracker_hosts %}
+      {%- set is_tasktracker_in_pillar = True %}
+      {% break %}
+    {%- endif %}
+  {%- endfor %}
+{%- endif %}
+
+{%- set is_jobtracker = is_jobtracker or jobtracker_host in minion_hosts %}
+
+{%- if is_tasktracker_in_pillar is defined %}
+  {%- set is_tasktracker = is_tasktracker or is_tasktracker_in_pillar %}
+{%- endif %}
 
 {%- set mapred = {} %}
 {%- do mapred.update({ 'jobtracker_port'               : jobtracker_port|string(),

--- a/hadoop/mapred/settings.sls
+++ b/hadoop/mapred/settings.sls
@@ -14,7 +14,7 @@
 {%- set tasktracker_target = g.get('tasktracker_target', p.get('tasktracker_target', 'roles:hadoop_slave')) %}
 {%- set targeting_method = salt['grains.get']('hadoop:targeting_method', salt['pillar.get']('hadoop:targeting_method', 'grain')) %}
 
-{%- set jobtracker_host  = salt['mine.get'](jobtracker_target, 'network.interfaces', expr_form=targeting_method)|first %}
+{%- set jobtracker_host  = g.get('jobtracker_host', p.get('jobtracker_host', salt['mine.get'](jobtracker_target, 'network.interfaces', expr_form=targeting_method)|first)) %}
 {%- set local_disks     = salt['grains.get']('mapred_data_disks', ['/data']) %}
 {%- set config_mapred_site = gc.get('mapred-site', pc.get('mapred-site', {})) %}
 

--- a/hadoop/mapred/uninstall.sls
+++ b/hadoop/mapred/uninstall.sls
@@ -1,0 +1,38 @@
+{%- from 'hadoop/settings.sls' import hadoop with context %}
+{%- from 'hadoop/mapred/settings.sls' import mapred with context %}
+
+hadoop-mapred-stopped:
+  service.dead:
+    - names: 
+      - hadoop-jobtracker
+      - hadoop-tasktracker
+    - enable: False
+
+hadoop-mapred-services-removed:
+  file.absent:
+    - names:
+      - /etc/systemd/system/hadoop-jobtracker.service
+      - /etc/init.d/hadoop-jobtracker
+      - /etc/systemd/system/hadoop-tasktracker.service
+      - /etc/init.d/hadoop-tasktracker
+    - require:
+      - service: hadoop-mapred-stopped
+{%- if grains.get('systemd') %}
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: hadoop-mapred-services-removed
+{%- endif %}
+
+hadoop-mapred-files-removed:
+  file.absent:
+    - names:
+      - {{ hadoop['alt_config'] }}/mapred-site.xml
+      - {{ hadoop['alt_config'] }}/taskcontroller.cfg
+
+hadoop-mapred-data-removed:
+  file.absent:
+    - names:
+{% for disk in mapred.local_disks %}
+      - {{ disk }}/mapred
+{% endfor %}

--- a/hadoop/settings.sls
+++ b/hadoop/settings.sls
@@ -3,9 +3,9 @@
 {% set g  = salt['grains.get']('hadoop', {}) %}
 {% set gc = g.get('config', {}) %}
 
-{%- set versions = {} %}
-{%- set default_dist_id = 'apache-2.2.0' %}
-{%- set dist_id = g.get('version', p.get('version', default_dist_id)) %}
+{%- set versions         = {} %}
+{%- set default_dist_id  = 'apache-2.2.0' %}
+{%- set dist_id          = g.get('version', p.get('version', default_dist_id)) %}
 
 {%- set default_versions = { 'apache-1.2.1' : { 'version'       : '1.2.1',
                                         'version_name'  : 'hadoop-1.2.1',
@@ -152,21 +152,21 @@
 {%- set targeting_method = g.get('targeting_method', p.get('targeting_method', 'grain')) %}
 
 {%- if version_info['major_version'] == '1' %}
-{%- set dfs_cmd = alt_home + '/bin/hadoop dfs' %}
-{%- set dfsadmin_cmd = alt_home + '/bin/hadoop dfsadmin' %}
+  {%- set dfs_cmd = alt_home + '/bin/hadoop dfs' %}
+  {%- set dfsadmin_cmd = alt_home + '/bin/hadoop dfsadmin' %}
 {%- else %}
-{%- set dfs_cmd = alt_home + '/bin/hdfs dfs' %}
-{%- set dfsadmin_cmd = alt_home + '/bin/hdfs dfsadmin' %}
+  {%- set dfs_cmd = alt_home + '/bin/hdfs dfs' %}
+  {%- set dfsadmin_cmd = alt_home + '/bin/hdfs dfsadmin' %}
 {%- endif %}
 
 {%- set java_home        = salt['grains.get']('java_home', salt['pillar.get']('java_home', '/usr/lib/java')) %}
 {%- set config_core_site = gc.get('core-site', pc.get('core-site', {})) %}
 
-{%- set users = { 'hadoop' : 6000,
-                  'hdfs'   : 6001,
-                  'mapred' : 6002,
-                  'yarn'   : 6003,
-                } %}
+{%- set users            = { 'hadoop' : 6000,
+                             'hdfs'   : 6001,
+                             'mapred' : 6002,
+                             'yarn'   : 6003,
+                           } %}
 
 {%- set hadoop = {} %}
 {%- do hadoop.update( {   'dist_id'          : dist_id,

--- a/hadoop/settings.sls
+++ b/hadoop/settings.sls
@@ -139,6 +139,7 @@
                                       },
                    }%}
 
+
 {%- set versions         = p.get('versions', default_versions) %}
 {%- set version_info     = versions.get(dist_id, versions['apache-2.8.0']) %}
 {%- set alt_home         = salt['pillar.get']('hadoop:prefix', '/usr/lib/hadoop') %}

--- a/hadoop/settings.sls
+++ b/hadoop/settings.sls
@@ -148,7 +148,7 @@
 {%- set real_config_dist = alt_config + '.dist' %}
 {%- set default_log_root = '/var/log/hadoop' %}
 {%- set log_root         = gc.get('log_root', pc.get('log_root', default_log_root)) %}
-{%- set initscript       = 'hadoop.init' %}
+{%- set initscript       = 'hadoop.service' if grains.get('systemd') else 'hadoop.init' %}
 {%- set targeting_method = g.get('targeting_method', p.get('targeting_method', 'grain')) %}
 
 {%- if version_info['major_version'] == '1' %}

--- a/hadoop/settings.sls
+++ b/hadoop/settings.sls
@@ -139,7 +139,6 @@
                                       },
                    }%}
 
-
 {%- set versions         = p.get('versions', default_versions) %}
 {%- set version_info     = versions.get(dist_id, versions['apache-2.8.0']) %}
 {%- set alt_home         = salt['pillar.get']('hadoop:prefix', '/usr/lib/hadoop') %}

--- a/hadoop/uninstall.sls
+++ b/hadoop/uninstall.sls
@@ -1,0 +1,25 @@
+{%- from 'hadoop/settings.sls' import hadoop with context %}
+
+hadoop-files-removed:
+  file.absent:
+    - names:
+      - {{ hadoop.log_root }}
+      - /var/run/hadoop
+      - /var/lib/hadoop
+      - /var/log/hadoop
+      - {{ hadoop['real_home'] }}
+      - {{ hadoop['alt_home'] }}
+      - /usr/bin/hadoop
+      - /usr/bin/hdfs
+      - /usr/bin/mapred
+      - /usr/bin/yarn
+      - /etc/profile.d/hadoop.sh
+      - /etc/hadoop
+      - {{ hadoop['real_config'] }}
+      - {{ hadoop['alt_config'] }}
+      - /etc/default/hadoop
+
+include:
+  - hadoop.mapred.uninstall
+  - hadoop.yarn.uninstall
+  - hadoop.hdfs.uninstall

--- a/hadoop/yarn/init.sls
+++ b/hadoop/yarn/init.sls
@@ -87,8 +87,13 @@ fix-executor-permissions:
 {{ hdfs_mkdir(yarn_home_directory, username, username, 700, hadoop.dfs_cmd) }}
 {{ hdfs_mkdir(rald, username, 'hadoop', 1777, hadoop.dfs_cmd) }}
 
-/etc/init.d/hadoop-historyserver:
+hadoop-historyserver-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-historyserver.service
+{% else %}
+    - name: /etc/init.d/hadoop-historyserver
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -99,13 +104,26 @@ fix-executor-permissions:
       hadoop_user: hdfs
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-historyserver-service
+    - watch_in:
+      - service: hadoop-historyserver
+{% endif %}
 
 hadoop-historyserver:
   service.running:
     - enable: True
 
-/etc/init.d/hadoop-resourcemanager:
+hadoop-resourcemanager-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-resourcemanager.service
+{% else %}
+    - name: /etc/init.d/hadoop-resourcemanager
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -116,6 +134,14 @@ hadoop-historyserver:
       hadoop_user: yarn
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-resourcemanager-service
+    - watch_in:
+      - service: hadoop-resourcemanager
+{% endif %}
 
 hadoop-resourcemanager:
   service.running:
@@ -124,8 +150,13 @@ hadoop-resourcemanager:
 
 {% if yarn.is_nodemanager %}
 
-/etc/init.d/hadoop-nodemanager:
+hadoop-nodemanager-service:
   file.managed:
+{%- if grains.get('systemd') %}
+    - name: /etc/systemd/system/hadoop-nodemanager.service
+{% else %}
+    - name: /etc/init.d/hadoop-nodemanager
+{% endif %}
     - source: salt://hadoop/files/{{ hadoop.initscript }}
     - user: root
     - group: root
@@ -136,6 +167,14 @@ hadoop-resourcemanager:
       hadoop_user: yarn
       hadoop_major: {{ hadoop.major_version }}
       hadoop_home: {{ hadoop.alt_home }}
+{%- if grains.get('systemd') %}
+  module.wait:
+    - name: service.systemctl_reload
+    - watch:
+      - file: hadoop-nodemanager-service
+    - watch_in:
+      - service: hadoop-nodemanager
+{% endif %}
 
 hadoop-nodemanager:
   service.running:

--- a/hadoop/yarn/init.sls
+++ b/hadoop/yarn/init.sls
@@ -4,7 +4,7 @@
 {%- from "hadoop/user_macro.sls" import hadoop_user with context %}
 {%- from 'hadoop/hdfs_mkdir_macro.sls' import hdfs_mkdir with context %}
 
-{%- if hadoop.major_version|string() == '2' %}
+{%- if hadoop.major_version|string() != '1' %}
 
 {% set username = 'yarn' %}
 {% set yarn_home_directory = '/user/' + username %}

--- a/hadoop/yarn/settings.sls
+++ b/hadoop/yarn/settings.sls
@@ -15,7 +15,8 @@
 {%- set nodemanager_target          = g.get('nodemanager_target', p.get('nodemanager_target', 'roles:hadoop_slave')) %}
 # this is a deliberate duplication as to not re-import hadoop/settings multiple times
 {%- set targeting_method            = salt['grains.get']('hadoop:targeting_method', salt['pillar.get']('hadoop:targeting_method', 'grain')) %}
-{%- set resourcemanager_host        = salt['mine.get'](resourcemanager_target, 'network.interfaces', expr_form=targeting_method)|first() %}
+{%- set resourcemanager_hosts       = g.get('resourcemanager_hosts', p.get('resourcemanager_hosts', salt['mine.get'](resourcemanager_target, 'network.interfaces', expr_form=targeting_method)|sort)) %}
+{%- set ha_cluster_id               = salt['grains.get']('ha_cluster_id', salt['pillar.get']('ha_cluster_id', 'hdfscluster')) %}
 
 {%- set local_disks                 = salt['grains.get']('yarn_data_disks', ['/yarn_data']) %}
 {%- set config_yarn_site            = gc.get('yarn-site', pc.get('yarn-site', {})) %}
@@ -23,8 +24,8 @@
 # these are system accounts blacklisted with the YARN LCE
 {%- set banned_users                = gc.get('banned_users', pc.get('banned_users', ['hdfs','yarn','mapred','bin'])) %}
 
-{%- set is_resourcemanager = salt['match.' ~ targeting_method](resourcemanager_target) %}
-{%- set is_nodemanager     = salt['match.' ~ targeting_method](nodemanager_target) %}
+{%- set is_resourcemanager          = salt['match.' ~ targeting_method](resourcemanager_target) %}
+{%- set is_nodemanager              = salt['match.' ~ targeting_method](nodemanager_target) %}
 
 {%- set yarn = {} %}
 {%- do yarn.update({ 'resourcetracker_port'        : resourcetracker_port,
@@ -32,7 +33,7 @@
                      'resourcemanager_port'        : resourcemanager_port,
                      'resourcemanager_webapp_port' : resourcemanager_webapp_port,
                      'resourcemanager_admin_port'  : resourcemanager_admin_port,
-                     'resourcemanager_host'        : resourcemanager_host,
+                     'resourcemanager_hosts'       : resourcemanager_hosts,
                      'nodemanager_port'            : nodemanager_port,
                      'nodemanager_webapp_port'     : nodemanager_webapp_port,
                      'nodemanager_localizer_port'  : nodemanager_localizer_port,
@@ -43,4 +44,5 @@
                      'banned_users'                : banned_users,
                      'is_resourcemanager'          : is_resourcemanager,
                      'is_nodemanager'              : is_nodemanager,
+                     'ha_cluster_id'               : ha_cluster_id,
                    }) %}

--- a/hadoop/yarn/uninstall.sls
+++ b/hadoop/yarn/uninstall.sls
@@ -1,0 +1,42 @@
+{%- from 'hadoop/settings.sls' import hadoop with context %}
+{%- from 'hadoop/yarn/settings.sls' import yarn with context %}
+
+hadoop-yarn-stopped:
+  service.dead:
+    - names: 
+      - hadoop-historyserver
+      - hadoop-resourcemanager
+      - hadoop-nodemanager
+    - enable: False
+
+hadoop-yarn-services-removed:
+  file.absent:
+    - names:
+      - /etc/systemd/system/hadoop-historyserver.service
+      - /etc/init.d/hadoop-historyserver
+      - /etc/systemd/system/hadoop-resourcemanager.service
+      - /etc/init.d/hadoop-resourcemanager
+      - /etc/systemd/system/hadoop-nodemanager.service
+      - /etc/init.d/hadoop-nodemanager
+    - require:
+      - service: hadoop-yarn-stopped
+{%- if grains.get('systemd') %}
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: hadoop-yarn-services-removed
+{%- endif %}
+
+hadoop-yarn-files-removed:
+  file.absent:
+    - names:
+      - {{ hadoop.alt_config }}/container-executor.cfg
+      - {{ hadoop.alt_config }}/yarn-site.xml
+      - {{ hadoop.alt_config }}/capacity-scheduler.xml
+
+hadoop-yarn-data-removed:
+  file.absent:
+    - names:
+{% for disk in yarn.local_disks %}
+      - {{ disk }}/yarn
+{% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,7 @@
 # java_home: /usr/lib/java
 
 hadoop:
-  version: apache-1.2.1 # ['apache-1.2.1', 'apache-2.2.0', 'hdp-1.3.0', 'hdp-2.2.0', 'cdh-4.5.0', 'cdh-4.5.0-mr1']
+  version: apache-1.2.1 # ['apache-1.2.1', 'apache-2.8.0', 'hdp-1.3.0', 'hdp-2.2.0', 'cdh-4.5.0', 'cdh-4.5.0-mr1']
   targeting_method: grain # [compound, glob] also supported
   users:
     hadoop: 6000

--- a/pillar_ha.example
+++ b/pillar_ha.example
@@ -1,11 +1,10 @@
 # a pillar example of aspects specific to HDFS Namenode High Availability
 # if HA is configured like below, there will be no secondary namenode
-# On each namenode you have to have a match of the namenode_target **and** either primary or secondary NN target
+# On each namenode you have to have a match of the namenode_target **and** primary NN target for one of your namenodes
 
 hdfs:
   namenode_target: "roles:hadoop_master" # Specify compound matching string to match both your namenodes
   primarynamenode_target: "roles:hdfs_namenode1" # this node will do the NN format, init zookeeper and run a zkfc
-  secondarynamenode_target: "roles:hdfs_namenode2" # will run the standby namenode and the other zkfc
   journalnode_target: "roles:hdfs_journalnode"
   datanode_target: "roles:hadoop_slave" # Specify compound matching string to match all your datanodes e.g. if you were to use pillar I@datanode:true
   config:
@@ -13,10 +12,9 @@ hdfs:
     namenode_http_port: 50070
     # the rest of hdfs config as usual
 
-# the yarn Resourcemanager needs specific targeting in a HA cluster - it cannot be
-# targeted with the default "hadoop_master" role here because then you would end up
-# with two RM processes - one on each namenode.
+# A pillar example of aspects specific to Resourcemanager High Availability
+# to use several Resourcemanager nodes you need to target it with `resourcemanager_target` option
 
 yarn:
-  resourcemanager_target: "roles:yarn_master"
+  resourcemanager_target: "roles:yarn_resourcemanager"
   # ... the rest goes as usual

--- a/pillar_multicluster.example
+++ b/pillar_multicluster.example
@@ -1,0 +1,86 @@
+# It is possible to specify several clusters in pillar directly. When you specify `clusters` parameter all other targeting methods will be omitted.
+# hdfs, yarn and mapred support multicluster options.
+# You can specify clusters in the next manner:
+#
+# hdfs:
+#   <cluster_name_1>:
+#     [cluster_options_1]
+#   <cluster_name_2>:
+#     [cluster_options_2]
+#
+# When hdfs, yarn or mapred state is executed on the node, it will try to determine to which cluster it is related.  
+# The node will try to fetch `ha_cluster_id` to determine to which cluster it is related. In case if `ha_cluster_id` is not specified (via Grains or Pillar)
+# it will try to find its IP, hostname or fqdn in all clusters to determine to which cluster it is related.
+# Be aware that you can't use the same node in two different clusters!
+
+# An example of using multiple clusters specified via Pillar:
+
+hdfs:
+  clusters:
+    cluster0:
+      primary_namenode_host: 192.168.1.101
+      namenode_hosts:
+        - 192.168.0.101
+        - 192.168.0.102
+      journalnode_hosts:
+        - 192.168.0.101
+        - 192.168.0.102
+        - 192.168.0.103
+      datanode_hosts:
+        - 192.168.0.101
+        - 192.168.0.102
+        - 192.168.0.103
+    cluster1:
+      primary_namenode_host: 192.168.1.101
+      namenode_hosts:
+        - 192.168.1.101
+        - 192.168.1.102
+        - 192.168.1.103
+      journalnode_hosts:
+        - 192.168.1.101
+        - 192.168.1.102
+        - 192.168.1.103
+      datanode_hosts:
+        - 192.168.1.101
+        - 192.168.1.102
+        - 192.168.1.103
+# Other options ...
+
+mapred:
+  clusters:
+    cluster0:
+      jobtracker_host: 192.168.0.101
+      tasktracker_hosts:
+        - 192.168.0.101
+        - 192.168.0.102
+        - 192.168.0.103
+      tasktrackers_on_datanodes: False # By setting this option to True you extend the `tasktracker_hosts` list with the list from `hdfs.datanode_hosts` of the same cluster. By default, this option is False
+    cluster1:
+      jobtracker_host: myhost1
+      tasktracker_hosts:
+        - myhost1
+        - myhost2
+        - myhost3
+# Other options ...
+
+yarn:
+  clusters:
+    cluster0:
+      resourcemanager_on_namenode: False # By setting this option to True you extend the `resourcemanager_hosts` list with the list from `hdfs.namenode_hosts` of the same cluster. By default, this option is False
+      nodemanagers_on_datanodes: False # By setting this option to True you extend the `nodemanager_hosts` list with the list from `hdfs.datanode_hosts` of the same cluster. By default, this option is False
+      resourcemanager_hosts:
+        - 192.168.0.101
+        - 192.168.0.102
+      nodemanager_hosts:
+        - 192.168.0.101
+        - 192.168.0.102
+        - 192.168.0.103
+    cluster1:
+      resourcemanager_hosts:
+        - resourcemanager1.mydomain.com
+        - resourcemanager2.mydomain.com
+      nodemanager_hosts:
+        - nodemanager1.mydomain.com
+        - nodemanager2.mydomain.com
+        - nodemanager3.mydomain.com
+# Other options ...

--- a/pillar_targeting.example
+++ b/pillar_targeting.example
@@ -25,7 +25,7 @@ mapred:
     - 192.168.0.101
     - 192.168.0.102
     - 192.168.0.103
-  tasktrackers_on_datanodes: False # By setting this option to True you extend the tasktracker_hosts list with the list from hdfs.datanode_hosts . By dafault, this option is False
+  tasktrackers_on_datanodes: False # By setting this option to True you extend the `tasktracker_hosts` list with the list from `hdfs.datanode_hosts`. By default, this option is False
 # Other options ...
 
 yarn:
@@ -36,6 +36,6 @@ yarn:
     - 192.168.0.101
     - 192.168.0.102
     - 192.168.0.103
-  resourcemanager_on_namenode: False # By setting this option to True you extend the resourcemanager_hosts list with the list from hdfs.namenode_hosts . By dafault, this option is False
-  nodemanagers_on_datanodes: False # By setting this option to True you extend the nodemanager_hosts list with the list from hdfs.datanode_hosts . By dafault, this option is False
+  resourcemanager_on_namenode: False # By setting this option to True you extend the `resourcemanager_hosts` list with the list from `hdfs.namenode_hosts`. By default, this option is False
+  nodemanagers_on_datanodes: False # By setting this option to True you extend the `nodemanager_hosts` list with the list from `hdfs.datanode_hosts`. By default, this option is False
 # Other options ...

--- a/pillar_targeting.example
+++ b/pillar_targeting.example
@@ -1,0 +1,41 @@
+# Except default targeting methods with `_target` suffix, it's possible to specify nodes directly in a pillar file.
+# When you use direct nodes specification with prefix `host` or `hosts` then other targeting methods are omitted.
+# You can substitute and targeting method with direct specification
+
+# An example of using a direct specification in pillar:
+
+hdfs:
+  primary_namenode_host: 192.168.0.101
+  namenode_hosts:
+    - 192.168.0.101
+    - 192.168.0.102
+  journalnode_hosts:
+    - 192.168.0.101
+    - 192.168.0.102
+    - 192.168.0.103
+  datanode_hosts:
+    - 192.168.0.101
+    - 192.168.0.102
+    - 192.168.0.103
+# Other options ...
+
+mapred:
+  jobtracker_host: 192.168.0.101
+  tasktracker_hosts:
+    - 192.168.0.101
+    - 192.168.0.102
+    - 192.168.0.103
+  tasktrackers_on_datanodes: False # By setting this option to True you extend the tasktracker_hosts list with the list from hdfs.datanode_hosts . By dafault, this option is False
+# Other options ...
+
+yarn:
+  resourcemanager_hosts:
+    - 192.168.0.101
+    - 192.168.0.102
+  nodemanager_hosts:
+    - 192.168.0.101
+    - 192.168.0.102
+    - 192.168.0.103
+  resourcemanager_on_namenode: False # By setting this option to True you extend the resourcemanager_hosts list with the list from hdfs.namenode_hosts . By dafault, this option is False
+  nodemanagers_on_datanodes: False # By setting this option to True you extend the nodemanager_hosts list with the list from hdfs.datanode_hosts . By dafault, this option is False
+# Other options ...


### PR DESCRIPTION
This PR is related to #48 

Additions:
  - Hadoop 3 support (more than 2 namenodes are supported for `major_verison` 3)
  - Pillar is extended with direct node specification (see `pillar_targeting.example`)
  - Pillar is extended with direct multicluster specification (see `pillar_multicluster.example`)
  - New `uninstall` states are created to remove Hadoop from the nodes in case it is no longer needed
  - High availability for resource manager is automatically used when more than 1 resourcemanager are specified

Fixes:
  - hadoop services were changed on systems which supports `systemd` becase init.d scripts don't work properly with systemctl (in case the service is started and failed / killed status still shows `active (running)`)
  - add `pidofproc` on systems which doesn't support it natively. (in CentOS the function presented in `/etc/init.d/functions`. It's not needed for CentOS because the first fix will be executed, but for additional security it's better to leave this fix)

Changes:
  - All namenodes are assumed to be secondary namenodes except the primary namenode. That is why `secondarynamenode_target` is no longer needed to be specified, but is still possible.
  - Alternatives were replaced by ordinary symbolic links. The problem is that SaltStack shows the error when you try to add the same symbolic link or remove symbolic link which is no longer available. Alternatives are great for manual setup, but it is painful for automatic setup. (Also, they definitely not needed for automatic setup).

The user won't notice any changes in case he doesn't change the pillar file.

Tested on CentOS 7.3 (hadoop 2.7.3, hadoop 2.8.0, hadoop-3.0.0-alpha2)